### PR TITLE
兼容 swagger 注解中添加 example，并且 example 值可能是 null 等的场景

### DIFF
--- a/lib/util/fixSwagger.ts
+++ b/lib/util/fixSwagger.ts
@@ -1,5 +1,5 @@
-import { CommonError } from './error';
 import { renameTypePrefix, testTypeNameValid } from './const';
+import { CommonError } from './error';
 
 const swaggerDefPrefix = '#/definitions/';
 
@@ -96,6 +96,11 @@ function fixRequestBody(data: any) {
 }
 
 function findRef(object: any) {
+  // 考虑到 example
+  if (!object || ({}).toString.call(object) !== '[object Object]') {
+    return [];
+  }
+
   if (object.$ref) {
     return [object];
   }

--- a/test/fixture/swagger/o_1.json
+++ b/test/fixture/swagger/o_1.json
@@ -71,6 +71,9 @@
             "type": "object",
             "additionalProperties": {
               "type": "string"
+            },
+            "example": {
+              "additionalProperties": null
             }
           },
           "errorCode": {

--- a/test/fixture/swagger/s_1.json
+++ b/test/fixture/swagger/s_1.json
@@ -67,6 +67,9 @@
           "type": "object",
           "additionalProperties": {
             "type": "string"
+          },
+          "example": {
+            "additionalProperties": null
           }
         },
         "errorCode": {

--- a/test/fixture/swagger/s_fixed.json
+++ b/test/fixture/swagger/s_fixed.json
@@ -67,6 +67,9 @@
           "type": "object",
           "additionalProperties": {
             "type": "string"
+          },
+          "example": {
+            "additionalProperties": null
           }
         },
         "errorCode": {


### PR DESCRIPTION
`@ApiModelProperty` swagger 注解中可添加 example，如果 example 是一个对象，并且 value 是 `null`，会导致解析出错。

在 `findRef` 中添加判断来支持这种情况。

![image](https://user-images.githubusercontent.com/646129/78755149-46a7ec00-79ab-11ea-876e-336031c52d86.png)
