### PR TITLE
customize request timeout with env

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ openapi-generator from swagger 2.0 or OpenAPI 3.0:
 
 `openapi-generator url http://xxx/v2/api-docs -c true`
 
+Default request timeout is 5000ms, customize timeout with `requestTimeout` env.
+
+`requestTimeout=10000 openapi-generator url http://xxx/v2/api-docs -c true`
+
 ## Use Config
 
 `openapi-generator config ./xxx.js` or `openapi-generator config ./xxx.json`

--- a/lib/util/requestData.ts
+++ b/lib/util/requestData.ts
@@ -1,8 +1,10 @@
 import * as request from 'request';
 
+const timeout = process.env.requestTimeout ? (parseInt(process.env.requestTimeout, 10) || 5000) : 5000;
+
 export async function requestData(url: string) {
   return new Promise<string>((resolve, reject) => {
-    request(url, { timeout: 5000 }, (error, response, body) => {
+    request(url, { timeout: timeout }, (error, response, body) => {
       if (error) {
         console.warn('[GenSDK] err', error);
         reject(error);


### PR DESCRIPTION
Sometimes the swagger server is too slowly, allow customize request timeout as a workaround.